### PR TITLE
Proton uri version v4

### DIFF
--- a/source/TuviAuthProtonLib/Messages/Auth.cs
+++ b/source/TuviAuthProtonLib/Messages/Auth.cs
@@ -24,7 +24,7 @@ namespace Tuvi.Auth.Proton.Messages
 {
     internal class Auth : PayloadMessage<Payloads.AuthResponse, Auth.Payload>
     {
-        public override Uri Endpoint => new Uri("/auth", UriKind.Relative);
+        public override Uri Endpoint => new Uri("/auth/v4", UriKind.Relative);
         public override HttpMethod Method => HttpMethod.Post;
         public Auth(Payload payload)
             : base(payload)

--- a/source/TuviAuthProtonLib/Messages/AuthInfo.cs
+++ b/source/TuviAuthProtonLib/Messages/AuthInfo.cs
@@ -24,7 +24,7 @@ namespace Tuvi.Auth.Proton.Messages
 {
     internal class AuthInfo : PayloadMessage<Payloads.AuthInfoResponse, AuthInfo.Payload>
     {
-        public override Uri Endpoint => new Uri("/auth/info", UriKind.Relative);
+        public override Uri Endpoint => new Uri("/auth/v4/info", UriKind.Relative);
         public override HttpMethod Method => HttpMethod.Post;
 
         public AuthInfo(Payload payload)

--- a/source/TuviAuthProtonLib/Messages/Logout.cs
+++ b/source/TuviAuthProtonLib/Messages/Logout.cs
@@ -26,7 +26,7 @@ namespace Tuvi.Auth.Proton.Messages
 {
     internal class Logout : PayloadMessage<CommonResponse>
     {
-        public override Uri Endpoint => new Uri("/auth", UriKind.Relative);
+        public override Uri Endpoint => new Uri("/auth/v4", UriKind.Relative);
         public override HttpMethod Method => HttpMethod.Delete;
 
         protected override EmptyRequest CreateRequest()

--- a/source/TuviAuthProtonLib/Messages/Refresh.cs
+++ b/source/TuviAuthProtonLib/Messages/Refresh.cs
@@ -25,7 +25,7 @@ namespace Tuvi.Auth.Proton.Messages
 {
     internal class Refresh : PayloadMessage<Payloads.RefreshResponse, Refresh.Payload>
     {
-        public override Uri Endpoint => new Uri("/auth/refresh", UriKind.Relative);
+        public override Uri Endpoint => new Uri("/auth/v4/refresh", UriKind.Relative);
         public override HttpMethod Method => HttpMethod.Post;
         public Refresh(Payload payload)
             : base(payload)

--- a/source/TuviAuthProtonLib/Messages/TwoFactorCode.cs
+++ b/source/TuviAuthProtonLib/Messages/TwoFactorCode.cs
@@ -24,7 +24,7 @@ namespace Tuvi.Auth.Proton.Messages
 {
     internal class TwoFactorCode : PayloadMessage<Payloads.TwoFactorCodeResponse, TwoFactorCode.Payload>
     {
-        public override Uri Endpoint => new Uri("/auth/2fa", UriKind.Relative);
+        public override Uri Endpoint => new Uri("/auth/v4/2fa", UriKind.Relative);
         public override HttpMethod Method => HttpMethod.Post;
         public TwoFactorCode(Payload payload)
             : base(payload)


### PR DESCRIPTION
update uri to uri from `go-proton-api`. Source code: [manager_auth.go](https://github.com/ProtonMail/go-proton-api/blob/master/manager_auth.go); [auth.go](https://github.com/ProtonMail/go-proton-api/blob/master/auth.go).

